### PR TITLE
fix:実機でのレイアウトずれ修正（タイマーの位置のみ修正）

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-01-07T15:10:17.447349Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=RFCN20MJ96M" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
       <SelectionState runConfigName="exactly_10_seconds_game_android_app">
         <option name="selectionMode" value="DROPDOWN" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main"
@@ -8,37 +7,31 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center_horizontal"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
+    <TextView
+        android:id="@+id/timeTextView"
+        android:layout_width="271dp"
+        android:layout_height="95dp"
+        android:layout_marginTop="229dp"
+        android:padding="15dp"
+        android:text="@string/sec"
+        android:textAlignment="center"
+        android:textSize="50sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/timeTextView"
-            android:layout_width="1086.px"
-            android:layout_height="382.px"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="916.px"
-            android:padding="15dp"
-            android:text="@string/sec"
-            android:textAlignment="center"
-            android:textSize="200.px" />
+    <Button
+        android:id="@+id/button"
+        android:layout_width="200dp"
+        android:layout_height="122dp"
+        android:layout_marginTop="184dp"
+        android:background="@drawable/custom_button"
+        android:text="@string/button_text_start"
+        android:textColor="@color/black"
+        android:textSize="25sp"
+        app:backgroundTint="@null"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/timeTextView" />
 
-        <Button
-            android:id="@+id/button"
-            android:layout_width="801.px"
-            android:layout_height="489.px"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="737.px"
-            android:background="@drawable/custom_button"
-            android:text="@string/button_text_start"
-            android:textColor="@color/black"
-            android:textSize="100.px"
-            app:backgroundTint="@null" />
-    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
エミュレータでは[Figma](https://www.figma.com/design/LiaE4Ot2XwJdX698Pt7pWt/10%E7%A7%92%E3%82%B8%E3%83%A3%E3%82%B9%E3%83%88%E3%81%A7%E6%AD%A2%E3%82%81%E3%82%8B%E3%82%B2%E3%83%BC%E3%83%A0_AndroidApp?node-id=13-17&t=vmGZ0Hxi5gGtudHh-0)のレイアウトと同じ位置にタイマーのテキストボックスとボタンが配置されていたが、実機では以下のようにレイアウトが大きくずれていたため、ざっくり修正した。

|修正前実機スクリーンショット|Figma|
|---|---|
|![実機レイアウトずれScreenshot_20250104_195817](https://github.com/user-attachments/assets/3e8ca174-cb67-4a3d-ab33-add4a3564b48)|![Galaxy S20 5G　画面初期表示ORリトライボタン押下](https://github.com/user-attachments/assets/b3eceb3c-e3cd-4bf4-a5a6-f59424717f7f)|

> [!WARNING]
> 今回はひとまず動かすことを優先して実装しているため、ボタンが見切れないようにするところまで修正することで一旦良しとした。
>厳密な ボタンの位置調整は別途行うつもり。

|修正後実機スクリーンショット|同左|同左|同左|Figma|Figmaとの差分（左：Figma、右：アプリ初期表示時）|
|---|---|--|--|--|--|
|アプリ初期表示時|スタートボタン押下時|ストップボタン押下時|リスタートボタン押下時|Figma|Figmaとの差分|
|![アプリ初期表示時_Screenshot_20250108_001304_exactly_10_seconds_game_android_app](https://github.com/user-attachments/assets/8ca4ab67-06b2-4232-8ad6-7e9ca35e64f7)|![スタートボタン押下時_Screenshot_20250108_001126_exactly_10_seconds_game_android_app](https://github.com/user-attachments/assets/974ba5f0-3439-4962-8595-4c1dd13d0ba6)|![ストップボタン押下時_Screenshot_20250108_001110_exactly_10_seconds_game_android_app](https://github.com/user-attachments/assets/2ea96194-3961-4a10-89b2-457988bcda5a)|![リスタートボタン押下時_Screenshot_20250108_001116_exactly_10_seconds_game_android_app](https://github.com/user-attachments/assets/e8a0f6e5-c1cf-43d8-a2f8-7e5cadffcc66)|![Galaxy S20 5G　画面初期表示ORリトライボタン押下](https://github.com/user-attachments/assets/2aa87246-a080-4ee2-a441-b08608f8fc59)|![2025-01-08_00h32_56](https://github.com/user-attachments/assets/05444fdb-0837-43c6-aa11-2d23245b3c47)|

> [!NOTE]
> - 実機はナイトモードになっているため配色がFigmaと違っている
> - レイアウト確認のため、アプリ初期表示時のスクリーンショットのみFigmaの大きさに合わせてある
