### PR TITLE
refactor:結果の吹き出しの背景を透過したものに差し替え

### DIFF
--- a/app/src/main/res/drawable/speech_bubble.xml
+++ b/app/src/main/res/drawable/speech_bubble.xml
@@ -1,18 +1,18 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="1200dp"
-    android:height="641dp"
-    android:viewportWidth="1200"
-    android:viewportHeight="641">
+    android:width="1201dp"
+    android:height="640dp"
+    android:viewportWidth="1201"
+    android:viewportHeight="640">
   <path
-      android:pathData="M0,0h1200v520h-1200z"
+      android:pathData="M600,519h1v1h-1z"
       android:fillColor="#ffffff"/>
   <path
-      android:pathData="M50,0L1150,0A50,50 0,0 1,1200 50L1200,470A50,50 0,0 1,1150 520L50,520A50,50 0,0 1,0 470L0,50A50,50 0,0 1,50 0z"
+      android:pathData="M50.5,0L1150.5,0A50,50 0,0 1,1200.5 50L1200.5,470A50,50 0,0 1,1150.5 520L50.5,520A50,50 0,0 1,0.5 470L0.5,50A50,50 0,0 1,50.5 0z"
       android:fillColor="#9E29C5"/>
   <path
-      android:pathData="M600,520h1v1h-1z"
+      android:pathData="M601,521h1v1h-1z"
       android:fillColor="#ffffff"/>
   <path
-      android:pathData="M600,633L665,520.5H535L600,633Z"
+      android:pathData="M601,632L666,519.5H536L601,632Z"
       android:fillColor="#9E29C5"/>
 </vector>


### PR DESCRIPTION
# 修正内容
結果の吹き出しの背景を透過したものに差し替え
（Figmaで吹き出しの背景を透過したものを作成し、その画像を切り出して既存のものと差し替えた）

|修正前|修正後|
|--|--|
|![修正前Screenshot_20250109_030043_exactly_10_seconds_game_android_app](https://github.com/user-attachments/assets/69f91f33-eff3-40d9-a3d7-8e4df36e4f4b)|![修正後Screenshot_20250116_023624_exactly_10_seconds_game_android_app](https://github.com/user-attachments/assets/bd09386a-3a09-48da-83d6-c86239472348)|

- Figma（修正した吹き出し）
    - https://www.figma.com/design/LiaE4Ot2XwJdX698Pt7pWt/10%E7%A7%92%E3%82%B8%E3%83%A3%E3%82%B9%E3%83%88%E3%81%A7%E6%AD%A2%E3%82%81%E3%82%8B%E3%82%B2%E3%83%BC%E3%83%A0_AndroidApp?node-id=81-7&t=cf6F9VlrmJ5OJZc1-0

# 参考サイト
- Figmaでいい感じの吹き出しをつくる
   - https://zenn.dev/012/articles/aa88cd919f97c8
